### PR TITLE
ENG-501 Remove version number from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     "require": {
         "php": ">=5.4.0"
     },
-    "version": "1.0.0",
     "license": "MIT",
     "autoload": {
         "psr-4" : {


### PR DESCRIPTION
It is recommended by both Packagist and composer to not put version number in composer.json file and use tags only to manage releases. Since we have a webhook set up, releasing a new version will just be creating new tag after this change. 

Jira Ticket: [ENG-501]

reference: https://packagist.org/about#how-to-update-packages

> The easiest way to manage versioning is to just omit the version field from the composer.json file. The version numbers will then be parsed from the tag and branch names.



[ENG-501]: https://boltpay.atlassian.net/browse/ENG-501