### PR TITLE
[ENG-500] Setup PhpUnit and add test forCurlClientTest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
-.idea
+.idea/
 .htaccess
 php.ini
+composer.lock
+vendor/

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,10 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=5.6.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^5"
     },
     "license": "MIT",
     "autoload": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+        backupGlobals="false"
+        colors="true"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        verbose="true"
+>
+    <testsuite name="UnitTest">
+        <directory suffix=".php">./tests</directory>
+    </testsuite>
+</phpunit>

--- a/tests/CurlClientTest.php
+++ b/tests/CurlClientTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace BoltPay\Http;
+
+include_once("FakeCurl.php");
+
+class CurlClientTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var string
+     */
+    private $apiKey = 'test_key';
+
+    /**
+     * @var string
+     */
+    private $url = 'https://api.github.com/users/hadley/orgs';
+
+    /**
+     * @var array
+     */
+    private $mockResponseHeader = [
+        'X-Bolt-Trace-Id' => 'test_trace_id',
+        'header1' => 'value1',
+        'header2' => 'value2'
+    ];
+
+    /**
+     * @var string
+     */
+    private $mockResponseBody = [
+        'X-Bolt-Trace-Id' => 'test_trace_id',
+        'header1' => 'value1',
+        'header2' => 'value2'
+    ];
+
+    /**
+     * @var CurlClient
+     */
+    private $curlClient;
+
+    protected function setUp()
+    {
+        $this->mockResponseHeader = [
+            'X-Bolt-Trace-Id' => 'test_trace_id',
+            'header1' => 'value1',
+            'header2' => 'value2'
+        ];
+
+        $this->mockResponseBody = json_encode([
+            'status' => 'OK'
+        ]);
+
+        $this->curlClient = new CurlClient($this->apiKey);
+    }
+
+    /**
+     * @test
+     */
+    public function get()
+    {
+        # mock curl response
+        $bolt_test_fake_curl = get_fake_curl_instance();
+        $bolt_test_fake_curl->mockResponseCode(200);
+        $bolt_test_fake_curl->mockResponseHeader($this->mockResponseHeader);
+        $bolt_test_fake_curl->mockResponseBody($this->mockResponseBody);
+
+        $response = $this->curlClient->get($this->url);
+
+        # check request headers
+        $requestHeaders = $bolt_test_fake_curl->getOption(CURLOPT_HTTPHEADER);
+        $this->assertTrue(in_array('Content-Type: application/json', $requestHeaders));
+        $this->assertTrue(in_array('Content-Length: 0', $requestHeaders));
+        $this->assertTrue(in_array('X-Api-Key: ' . $this->apiKey, $requestHeaders));
+        $this->assertTrue(in_array('User-Agent: BoltPay/PHP-Client-0.1', $requestHeaders));
+
+        # check url
+        $this->assertEquals($this->url, $bolt_test_fake_curl->getURL());
+
+        # check options
+        $this->assertEquals(true, $bolt_test_fake_curl->getOption(CURLOPT_RETURNTRANSFER));
+        $this->assertEquals(true, $bolt_test_fake_curl->getOption(CURLOPT_HEADER));
+
+        # check response
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('test_trace_id', $response->getTraceId());
+        $this->assertEquals($this->mockResponseBody, json_encode($response->getBody()));
+    }
+
+    /**
+     * @test
+     */
+    public function post()
+    {
+        # mock curl response
+        $bolt_test_fake_curl = get_fake_curl_instance();
+        $bolt_test_fake_curl->mockResponseCode(200);
+        $bolt_test_fake_curl->mockResponseHeader($this->mockResponseHeader);
+        $bolt_test_fake_curl->mockResponseBody($this->mockResponseBody);
+
+        $params = [
+            'param1' => 'value1',
+            'param2' => 'value2'
+        ];
+        $response = $this->curlClient->post($this->url, $params);
+
+        # check url
+        $this->assertEquals($this->url, $bolt_test_fake_curl->getURL());
+
+        # check request headers
+        $requestHeaders = $bolt_test_fake_curl->getOption(CURLOPT_HTTPHEADER);
+        $this->assertTrue(in_array('Content-Type: application/json', $requestHeaders));
+        $this->assertTrue(in_array('Content-Length: ' . strlen(json_encode($params)), $requestHeaders));
+        $this->assertTrue(in_array('X-Api-Key: ' . $this->apiKey, $requestHeaders));
+        $this->assertTrue(in_array('User-Agent: BoltPay/PHP-Client-0.1', $requestHeaders));
+
+
+        # check other options
+        $this->assertEquals(1, $bolt_test_fake_curl->getOption(CURLOPT_POST));
+        $this->assertEquals(json_encode($params), $bolt_test_fake_curl->getOption(CURLOPT_POSTFIELDS));
+        $this->assertEquals(true, $bolt_test_fake_curl->getOption(CURLOPT_RETURNTRANSFER));
+        $this->assertEquals(true, $bolt_test_fake_curl->getOption(CURLOPT_HEADER));
+
+        # check response
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('test_trace_id', $response->getTraceId());
+        $this->assertEquals($this->mockResponseBody, json_encode($response->getBody()));
+    }
+}

--- a/tests/CurlClientTest.php
+++ b/tests/CurlClientTest.php
@@ -57,7 +57,12 @@ class CurlClientTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function get()
+
+    /**
+     * @test
+     * get method should set proper curl options including request headers and return response as expected
+     */
+    public function get_happyPath()
     {
         # mock curl response
         $bolt_test_fake_curl = get_fake_curl_instance();
@@ -89,8 +94,9 @@ class CurlClientTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
+     * post method should set proper curl options including request headers and return response as expected
      */
-    public function post()
+    public function post_happyPath()
     {
         # mock curl response
         $bolt_test_fake_curl = get_fake_curl_instance();

--- a/tests/FakeCurl.php
+++ b/tests/FakeCurl.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace BoltPay\Http;
+
+function get_fake_curl_instance()
+{
+    global $bolt_test_fake_curl;
+    if ($bolt_test_fake_curl == null) {
+        return $bolt_test_fake_curl = new FakeCurl();
+    } else {
+        return $bolt_test_fake_curl;
+    }
+}
+
+function curl_init($url)
+{
+    global $bolt_test_fake_curl;
+    $bolt_test_fake_curl->setURL($url);
+    return $bolt_test_fake_curl;
+}
+
+function curl_setopt($ch, $option, $value)
+{
+    $ch->setOption($option, $value);
+}
+
+function curl_exec($ch)
+{
+    return $ch->execute();
+}
+
+function curl_getinfo($ch, $opt = -1)
+{
+    return $ch->getInfo($opt);
+}
+
+function curl_close($ch)
+{
+    $ch = null;
+}
+
+class FakeCurl
+{
+    private $url;
+    private $optMap;
+    private $infoMap;
+
+    private $responseCode;
+    private $responseHeaderStr;
+    private $responseBodyStr;
+
+    public function __construct()
+    {
+        $this->optMap = array();
+        $this->infoMap = array();
+    }
+
+    public function getURL()
+    {
+        return $this->url;
+    }
+
+    public function setURL($url)
+    {
+        return $this->url = $url;
+    }
+
+    public function getOptions()
+    {
+        return $this->optMap;
+    }
+
+    public function getOption($option)
+    {
+        return $this->optMap[strval($option)];
+    }
+
+    public function setOption($option, $value)
+    {
+        $this->optMap["$option"] = $value;
+    }
+
+    public function mockResponseCode($statusCode)
+    {
+        $this->responseCode = $statusCode;
+    }
+
+    public function mockResponseHeader($headerArray)
+    {
+        $s = '';
+        foreach ($headerArray as $key => $value) {
+            $s = $s . "$key: $value\r\n";
+        }
+        $this->responseHeaderStr = $s . "\r\n";
+    }
+
+    public function mockResponseBody($responseBodyStr)
+    {
+        $this->responseBodyStr = $responseBodyStr;
+    }
+
+    public function getInfo($option)
+    {
+        if ($option == CURLINFO_HTTP_CODE) {
+            return $this->responseCode;
+        } elseif ($option == CURLINFO_HEADER_SIZE) {
+            return strlen($this->responseHeaderStr);
+        }
+        return '';
+    }
+
+    public function execute()
+    {
+        return $this->responseHeaderStr . $this->responseBodyStr;
+    }
+}


### PR DESCRIPTION
This PR configures PhpUnit for the project and added tests for get() and post() methods from CurlClient. 

FakeCurl.php is created to mock the behavior of curl. 

It also drops support for PHP 5.4 and 5.5

Jira Link: [ENG-500]

[ENG-500]: https://boltpay.atlassian.net/browse/ENG-500