### PR TITLE
Update deprecated circleci images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
       php-version:
         type: string
     docker:
-      - image: circleci/php:<< parameters.php-version >>
+      - image: cimg/php:<< parameters.php-version >>
     steps:
       - checkout # check out the code in the project directory
       - run:


### PR DESCRIPTION
Updates deprecated circleci php image per [this](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034) article.

Fixes: https://app.asana.com/0/1200228121876494/1201724719435423/f

#changelog Update deprecated circleci php image
Update deprecated circleci php image

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201724719435433